### PR TITLE
Prevent redirect to get_token_url in feed

### DIFF
--- a/laterpay/application/Controller/Post.php
+++ b/laterpay/application/Controller/Post.php
@@ -407,7 +407,7 @@ class LaterPay_Controller_Post extends LaterPay_Controller_Abstract
             $context
         );
 
-        if ( ! $browser_supports_cookies || $browser_is_crawler ) {
+        if ( ! $browser_supports_cookies || $browser_is_crawler || is_feed() ) {
             return;
         }
 


### PR DESCRIPTION
This is a hotfix to prevent a redirect loop on feed access from the browser (when cookies are supported) on systems with page caching like WP Engine (happend on Gutjahrs blog).
